### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint and unit tests (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['20.x', '22.x']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci
+      - run: npm test
+
+  integration:
+    name: VS Code integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: npm
+      - run: npm ci
+      # The extension host needs a display, which xvfb provides.
+      - run: xvfb-run -a npm run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20.x', '22.x']
+        node: ['22.x', '24.x']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -33,10 +33,10 @@ jobs:
     name: VS Code integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: npm
       - run: npm ci
       # The extension host needs a display, which xvfb provides.

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,3 +1,4 @@
+.github/**
 .vscode/**
 .vscode-test/**
 out/test/**

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,9 +2,19 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
+const EXTENSION_ID = 'yuna611d.batchencodingconverter';
+
 suite('Extension', () => {
 
-    test('contributes both conversion commands', async () => {
+    test('registers both conversion commands when activated', async () => {
+        const extension = vscode.extensions.getExtension(EXTENSION_ID);
+        if (!extension) {
+            assert.fail(`extension ${EXTENSION_ID} was not found`);
+        }
+
+        // The commands are contributed with `onCommand:` activation events, so they
+        // only reach the command registry once activate() has run.
+        await extension.activate();
         const commands = await vscode.commands.getCommands(true);
 
         assert.notStrictEqual(commands.indexOf('extension.convertSjisToUTF8'), -1);


### PR DESCRIPTION
Follow-up to #12 and #13. The repository had no CI, so pull requests — including Dependabot's — carried no automated signal.

## Jobs

**`test`** — `npm ci` then `npm test` (eslint, `tsc`, 11 unit tests) on Node 22 and 24. Needs nothing beyond the npm registry, so it is fast and is the job worth gating merges on.

**`integration`** — `npm run test:integration` under `xvfb-run`, which downloads a VS Code build and runs the extension host suite. The extension host needs a display; xvfb provides a virtual one.

Both run on `pull_request` and on pushes to `master`, with `permissions: contents: read` and a `concurrency` group that cancels superseded runs. `.vscodeignore` now excludes `.github/**` so the workflow is not packaged into the `.vsix`.

## The first run caught a real bug

I could not dry-run the `integration` job locally — this sandbox blocks `update.code.visualstudio.com`. Its first run on GitHub's runners failed, and the failure was genuine: the integration test added in #13 was wrong.

```
1) Extension contributes both conversion commands:
   AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: -1
```

The extension declares `onCommand:` activation events, so it activates lazily. `contributes.commands` only feeds the command palette — the ids reach the command registry when `activate()` calls `registerCommand`. The test queried `getCommands()` before activating, so it failed against a perfectly correct extension. My local stub did not model lazy activation, which is why #13 missed it.

Fixed by resolving the extension and awaiting `activate()` first, which also makes the test assert something worth asserting: that `activate()` registers both commands.

Also bumped `actions/checkout` and `actions/setup-node` to v5 (the runner warned the v4 actions run on deprecated Node 20) and moved the matrix off Node 20, which reached end of life in April 2026.

## Verification

All three jobs green on `30c3bae`:

| Job | Result |
| --- | --- |
| Lint and unit tests (Node 22.x) | success |
| Lint and unit tests (Node 24.x) | success |
| VS Code integration tests | success |

The integration job's log confirms the extension really loaded and activated in the host:

```
Loading development extension at /home/runner/work/BatchEncodingConverter/BatchEncodingConverter
NativeExtensionHostFactory...myExtensions: yuna611d.batchencodingconverter,...

  Extension
    ✔ registers both conversion commands when activated (66ms)

  1 passing (83ms)
Extension host test runner exit code: 0
```

## Note on the remaining audit findings

`npm audit` reports 3 dev-only findings (`diff`, `serialize-javascript`, both transitive under mocha). They are not shipped — devDependencies are not bundled, and `.vscodeignore` excludes `out/test/**`. Clearing them needs a mocha downgrade, so they are left as-is; with this workflow in place, any future Dependabot PR for them will be checked automatically.